### PR TITLE
fix(i18n-ko_kr): improve newly added string

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -442,7 +442,7 @@ const i18next_data = {
                 "Ron"     : "론",
                 "Tsumo"   : "쯔모",
                 "win-by"  : "{{winner}}의 {{type}}",
-                "ron-full"  : "{{winner}}의 론 {{loser}}",
+                "ron-full"  : "{{winner}}의 {{loser}} 론",
                 "tsumo-full"  : "{{winner}}의 쯔모",
                 "流局"    : "유국",
                 "流し満貫" : "유국만관",


### PR DESCRIPTION
#14 

tl;dr: This isn't 100% natural but it's best for now I guess.

The translation looks "too brief" but making it more natural requires extensive code changes just for one language so I'm afraid it will overcomplicate the business logic. For current stage, I feel what we lose more (maintainability) than gaining(one more natural string). 

---

longer explanations (for any Korean speakers in doubt)

In Korean, Ron is only used as a noun, we have `쏘다` for the verb form. 

So 100% natural one should be like "{{winner}}'s ron by ronning {{loser}}", which in Korean looks like "대면이 하가를 쏘아서 론" (toimen rons shimo).  

But what complicates matters is that Korean particle (as opposed to English articles (e.g. `a`, `the`) change their form by preceding word. In this case, particles are `이` (in `대면이`), and `를` (in `하가를`). So, given below:

```
"Hero" : "나"
"Shimo" : "하가"
"Toimen" : "대면"
"Kami" : "상가"
```
with particles, it becomes
(someone is subject: `이` and `가`)
```
"Hero" : "내가" // the word itself changes, as Latin or Spanish. 
"Shimo" : "하가가" 
"Toimen" : "대면이"
"Kami" : "상가가"
```
(someone is object: `을` and `를`)
```
"Hero" : "나를"
"Shimo" : "하가를" 
"Toimen" : "대면을"
"Kami" : "상가를"
```

I'm not familiar with i18next but from my experience from my work, this kind of special handling requires extensive specialized codes so I just settled with omitting all particles. It is grammatically OK, just it sounds too formal or too simple. 