### PR TITLE
fix text orientation of winds for CJK

### DIFF
--- a/style.css
+++ b/style.css
@@ -276,6 +276,7 @@ h1{
 .gi-p1-outer {
     grid-area: ai-p1;
     writing-mode: vertical-rl;
+    text-orientation: sideways;
     transform: rotate(180deg);
     margin: calc(var(--zoom) * 10px) auto;
 }
@@ -287,6 +288,7 @@ h1{
 .gi-p3-outer {
     grid-area: ai-p3;
     writing-mode: vertical-rl;
+    text-orientation: sideways;
     margin: calc(var(--zoom) * 10px) auto;
 }
 .rotate > img {


### PR DESCRIPTION
## TL; DR
- When CJK (Chinese, Japanese, Korean) is displayed in vertical mode, the characters are upright.
- Players' winds are also displayed upright. It is unexpected.
- Fixed them to be displayed sideways.

## Problem
When CJK (Chinese, Japanese, Korean) is displayed in vertical mode, the characters are upright.
Therefore, Shimocha and Kamicha's wind are displayed upright unexpectedly.

This image is in Japanese(東南西北), but Chinese and Korean have the same problem.
![image](https://github.com/killerducky/killer_mortal_gui/assets/35532793/95eabb32-e0af-4a98-8ef4-fe334ee5daa2)

## Solution
[`text-orientation: sideways`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation) makes CJK in sideways in vertical mode.
![image](https://github.com/killerducky/killer_mortal_gui/assets/35532793/11296201-b98a-4453-a578-04d7ef2ab4a8)

This change does not affect English.
![image](https://github.com/killerducky/killer_mortal_gui/assets/35532793/cf686aae-e2a7-47df-8870-deb4dcbeb1b3)
